### PR TITLE
Propose plugin manifest standardisation

### DIFF
--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -52,14 +52,17 @@ I propose the following schema:
     },
     "media": {
       "description": "The absolute URL of an image to display with your plugin",
-      "type": "string"
+      "type": [ "array", "string" ],
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [ "name", "description", "author", "file" ]
 }
 ```
 
-The following are two examples of acceptable manifests:
+The following are examples of acceptable manifests:
 ```json
 {
   "name": "My awesome plugin",
@@ -76,6 +79,15 @@ The following are two examples of acceptable manifests:
   "author": "generic name",
   "file": "index.js",
   "media": "https://cumcord.com/assets/screenshots/lmao.png"
+}
+```
+```json
+{
+  "name": "My awesome plugin",
+  "description": "A plugin that has lots of cool screenshot",
+  "author": "generic name",
+  "file": "index.js",
+  "media": [ "https://cumcord.com/assets/screenshots/lmao.png", "https://cumcord.com/piss.png" ]
 }
 ```
 

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -1,47 +1,22 @@
 # Plugin manifest standards proposal
 
-Cumcord plugins are required to have a manifest containing essential information and metadata about the plugin.
-This includes the plugin name, author, and a short description.
+## Description Of Issue
+Plugin manifests should be documented and standardised to prevent addition of unnecessary items by potentially multiple 3rd parties.
 
-The manifest is required to be a plain json object adhering to the following structure:
-```json
-{
-  "name": string,
-  "description": string,
-  "author": string,
-  "file": string file path,
-  "license": string,
-  "media": optional string absolute URL
-}
-```
+## Solution
+Standardise and document that the manifest must be a json, what the fields must be, and what each is for.
 
-## Name
-The name field must contain the name of the plugin to identify it, and to show in user interfaces.
+## Advantages
 
-## Description
-The description field must exist, and contain a short description of what the plugin does, and any additional info the plugin developer wishes to specify.
-It may be an empty string if the developer considers the plugin purpose simple enough, and the name self-explanatory enough.
+ - prevent 3rd parties from adding their own fields to manifests for their own use, cluttering repos.
+ - act as documentation for plugin developers on what to include in their manifest
 
-## Author
-The author field must contain the author of the plugin. Multiple authors must be specified, and while no format is required,
-the recommended format for this is to comma-separate the authors, using "and" for the last two, with no comma before the and.
+## Disadvantages
 
-Discord tags may be optionally used, but there is no requirement nor special handling for this.
+ - locks down possibly helpful info that can be included in manifests
+ - will likely be very verbose
 
-## File
-The file field is non-negotiably required to point relatively to the index Javascript file on disk.
-This is so that the development tool (sperm) can bundle the plugin.
-
-This file must meet the following criteria:
- - either a Javascript (\*.js) or React JSX (\*.jsx) file
- - default export a function to be called on load - see the plugin code format specification
-
-## License
-The license field must contain an [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)
-for the licence under which your plugin's content falls.
-
-No limitations are placed upon accepatble licenses - even proprietary licenses are accepatble, however we do recommend [OSI-approved licenses](https://opensource.org/licenses).
-
-## Media
-The media field need not exist, but if it does exist, it should specify a banner image to use to represent your plugin.
-This may be a descriptive screenshot, or a more marketing-style banner, or really anything you want.
+## General Implementation Details
+ - Include the `media` field - though it is not required for cc, since the Discord bot already uses it and I have seen it used in the wild,
+   I think it's sensible to standardise.
+ - Require the `license` field to be a valid [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -59,6 +59,27 @@ I propose the following schema:
 }
 ```
 
+The following are two examples of acceptable manifests:
+```json
+{
+  "name": "My awesome plugin",
+  "description": "A plugin that does a thing to your Discord, thus being awesome",
+  "author": "Yellowsink",
+  "file": "index.js",
+  "license": "Unlicense"
+}
+```
+```json
+{
+  "name": "My awesome plugin",
+  "description": "A plugin that has a cool screenshot",
+  "author": "Yellowsink",
+  "file": "index.js",
+  "license": "Unlicense",
+  "media": "https://cumcord.com/assets/screenshots/lmao.png"
+}
+```
+
 ---
 
 Author: Yellowsink <yellowsink@protonmail.com>

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -20,3 +20,41 @@ Standardise and document that the manifest must be a json, what the fields must 
  - Include the `media` field - though it is not required for cc, since the Discord bot already uses it and I have seen it used in the wild,
    I think it's sensible to standardise.
  - Require the `license` field to be a valid [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)
+
+I propose the following schema:
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "N/A",
+  "title": "Cumcord Plugin Manifest",
+  "description": "The manifest format for Cumcord plugins",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the plugin",
+      "type": "string"
+    },
+    "description": {
+      "description": "A more detail description for extra info about what the plugin does",
+      "type": "string"
+    },
+    "author": {
+      "description": "Who wrote the plugin; not required to be just one person",
+      "type": "string"
+    },
+    "file": {
+      "description": "The relative location on disk of the index JS file",
+      "type": "string"
+    },
+    "license": {
+      "description": "An SPDX identifier for the license of your plugin content",
+      "type": "string"
+    },
+    "media": {
+      "description": "The absolute URL of an image to display with your plugin",
+      "type": "string"
+    }
+  },
+  "required": [ "name", "description", "author", "file", "license" ]
+}
+```

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -64,7 +64,7 @@ The following are two examples of acceptable manifests:
 {
   "name": "My awesome plugin",
   "description": "A plugin that does a thing to your Discord, thus being awesome",
-  "author": "Yellowsink",
+  "author": "generic name",
   "file": "index.js",
   "license": "Unlicense"
 }
@@ -73,7 +73,7 @@ The following are two examples of acceptable manifests:
 {
   "name": "My awesome plugin",
   "description": "A plugin that has a cool screenshot",
-  "author": "Yellowsink",
+  "author": "generic name",
   "file": "index.js",
   "license": "Unlicense",
   "media": "https://cumcord.com/assets/screenshots/lmao.png"

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -58,3 +58,7 @@ I propose the following schema:
   "required": [ "name", "description", "author", "file", "license" ]
 }
 ```
+
+---
+
+Author: Yellowsink <yellowsink@protonmail.com>

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -1,0 +1,47 @@
+# Plugin manifest standards proposal
+
+Cumcord plugins are required to have a manifest containing essential information and metadata about the plugin.
+This includes the plugin name, author, and a short description.
+
+The manifest is required to be a plain json object adhering to the following structure:
+```json
+{
+  "name": string,
+  "description": string,
+  "author": string,
+  "file": string file path,
+  "license": string,
+  "media": optional string absolute URL
+}
+```
+
+## Name
+The name field must contain the name of the plugin to identify it, and to show in user interfaces.
+
+## Description
+The description field must exist, and contain a short description of what the plugin does, and any additional info the plugin developer wishes to specify.
+It may be an empty string if the developer considers the plugin purpose simple enough, and the name self-explanatory enough.
+
+## Author
+The author field must contain the author of the plugin. Multiple authors must be specified, and while no format is required,
+the recommended format for this is to comma-separate the authors, using "and" for the last two, with no comma before the and.
+
+Discord tags may be optionally used, but there is no requirement nor special handling for this.
+
+## File
+The file field is non-negotiably required to point relatively to the index Javascript file on disk.
+This is so that the development tool (sperm) can bundle the plugin.
+
+This file must meet the following criteria:
+ - either a Javascript (\*.js) or React JSX (\*.jsx) file
+ - default export a function to be called on load - see the plugin code format specification
+
+## License
+The license field must contain an [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)
+for the licence under which your plugin's content falls.
+
+No limitations are placed upon accepatble licenses - even proprietary licenses are accepatble, however we do recommend [OSI-approved licenses](https://opensource.org/licenses).
+
+## Media
+The media field need not exist, but if it does exist, it should specify a banner image to use to represent your plugin.
+This may be a descriptive screenshot, or a more marketing-style banner, or really anything you want.

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -55,7 +55,7 @@ I propose the following schema:
       "type": "string"
     }
   },
-  "required": [ "name", "description", "author", "file", "license" ]
+  "required": [ "name", "description", "author", "file" ]
 }
 ```
 
@@ -75,7 +75,6 @@ The following are two examples of acceptable manifests:
   "description": "A plugin that has a cool screenshot",
   "author": "generic name",
   "file": "index.js",
-  "license": "Unlicense",
   "media": "https://cumcord.com/assets/screenshots/lmao.png"
 }
 ```


### PR DESCRIPTION
## Description Of Issue
Plugin manifests should be documented and standardised to prevent addition of unnecessary items by potentially multiple 3rd parties.

## Solution
Standardise and document that the manifest must be a json, what the fields must be, and what each is for.