### PR TITLE
Propose theme manifest standardisation

### DIFF
--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -1,52 +1,20 @@
-# Theme manifest standards proposal
+# Plugin manifest standards proposal
 
-## Note on themes
-Themes are not included in the core functionality of Cumcord,
-however loader plugins should use the formats specified here to allow anyone to setup a repository,
-confident that any loader plugins will work with it.
+## Description Of Issue
+Theme manifests should be documented and standardised. While themes are not part of Cumcord itself,
+they are an essential part of most users' client mod experience,
+so when theme loader plugins inevitably appear, the manifest (and repo) formats should be standardised and cross-compatible.
 
-Cumcord themes are required to have a manifest containing essential information and metadata about the theme.
-This includes the theme name, author, and a short description.
+## Solution
+Standardise and document the manifest format (new-BD-style), what the fields must be, and what each is for.
 
-The manifest is required to be a plain json object adhering to the following structure:
-```json
-{
-  "name": string,
-  "description": string,
-  "author": string,
-  "file": string file path,
-  "license": string,
-  "media": optional string absolute URL
-}
-```
+## Advantages
 
-## Name
-The name field must contain the name of the plugin to identify it, and to show in user interfaces.
+ - prevent 3rd parties from adding their own fields to manifests for their own use, cluttering repos.
+ - act as documentation for theme developers on what to include in their manifest
 
-## Description
-The description field must exist, and contain a short description of the theme, and any additional info the theme developer wishes to specify.
-It may be an empty string if the developer considers the theme simple enough, and the name self-explanatory enough.
+## Disadvantages
+ - locks down possibly helpful info that can be included in manifests
 
-## Author
-The author field must contain the author of the plugin. Multiple authors must be specified, and while no format is required,
-the recommended format for this is to comma-separate the authors, using "and" for the last two, with no comma before the and.
-
-Discord tags may be optionally used, but there is no requirement nor special handling for this.
-
-## File
-The file field is non-negotiably required to point relatively to the index Javascript file on disk.
-This is so that the development tool (sperm) can bundle the plugin.
-
-This file must meet the following criteria:
- - either a Javascript (\*.js) or React JSX (\*.jsx) file
- - default export a function to be called on load - see the plugin code format specification
-
-## License
-The license field must contain an [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)
-for the licence under which your plugin's content falls.
-
-No limitations are placed upon accepatble licenses - even proprietary licenses are accepatble, however we do recommend [OSI-approved licenses](https://opensource.org/licenses).
-
-## Media
-The media field need not exist, but if it does exist, it should specify a banner image to use to represent your plugin.
-This may be a descriptive screenshot, or a more marketing-style banner, or really anything you want.
+## General Implementation Details
+ - only new BD style manifests should be carried forward into CC themes - not `//META`-style manifests

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -35,3 +35,7 @@ declare class ThemeManifest {
  media?:      URL;
 }
 ```
+
+---
+
+Author: Yellowsink <yellowsink@protonmail.com>

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -36,10 +36,6 @@ I propose the following schema:
       "description": "A more detail description for extra info about the theme",
       "type": "string"
     },
-    "authorId": {
-      "description": "The Discord ID of the theme's author - only one allowed, prioritised over author",
-      "type": "string"
-    },
     "author": {
       "description": "Who wrote the plugin; not required to be just one person",
       "type": "string"
@@ -54,10 +50,6 @@ I propose the following schema:
       "items": {
         "type": "string"
       }
-    },
-    "source": {
-      "description": "A link to of the source code repo of the theme",
-      "type": "string"
     }
   },
   "required": [ "name", "description", "author" ]
@@ -69,15 +61,13 @@ For example the media field may be just a single string, and some fields may be 
 ```json
 {
   "name": "My awesome theme",
-  "description": "A cool theme to demonstrate manifests",
-  "authorId": "123456789012345678",
+  "description": "A cool theme to demonstrate manifests"
   "author": "generic name",
   "license": "BSD-3",
   "media": [
     "https://cumcord.com/assets/screenshots/codcum.png",
     "https://cumcord.com/assets/screenshots/lmao.png"
-  ],
-  "source": "https://example.com/generic_name/my_awesome_theme_repo"
+  ]
 }
 
 ```

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -6,7 +6,7 @@ they are an essential part of most users' client mod experience,
 so when theme loader plugins inevitably appear, the manifest (and repo) formats should be standardised and cross-compatible.
 
 ## Solution
-Standardise and document the manifest format (new-BD-style), what the fields must be, and what each is for.
+Standardise and document the manifest format, what the fields must be, and what each is for.
 
 ## Advantages
 
@@ -17,42 +17,69 @@ Standardise and document the manifest format (new-BD-style), what the fields mus
  - locks down possibly helpful info that can be included in manifests
 
 ## General Implementation Details
- - only new BD style manifests should be carried forward into CC themes - not `//META`-style manifests
+ - use plugin manifest -like json manifests
 
-I propose the following TypeScript declaration, not because it has any direct use,
-but purely to concretely define the data structure required:
-```ts
-declare class ThemeManifest {
- // The name of the theme
- name:        string;
- // A more detail description for extra info about the theme
- description: string;
- // The Discord ID of the theme's author - only one allowed, prioritised over author
- authorId?:   string;
- // Who wrote the theme; not required to be just one person
- author:      string;
- // An SPDX identifier for the license of your theme content - https://spdx.org/licenses/
- license?:    string;
- // The absolute URL of an image to go with your theme, screenshot or otherwise
- media?:      URL;
- // The absolute URL to the source code repo of the theme
- source?:     URL;
+I propose the following schema:
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "N/A",
+  "title": "Cumcord Theme Manifest",
+  "description": "The manifest format for Cumcord themes",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the theme",
+      "type": "string"
+    },
+    "description": {
+      "description": "A more detail description for extra info about the theme",
+      "type": "string"
+    },
+    "authorId": {
+      "description": "The Discord ID of the theme's author - only one allowed, prioritised over author",
+      "type": "string"
+    },
+    "author": {
+      "description": "Who wrote the plugin; not required to be just one person",
+      "type": "string"
+    },
+    "license": {
+      "description": "An SPDX identifier for the license of your plugin content",
+      "type": "string"
+    },
+    "media": {
+      "description": "The absolute URL of an image to display with your plugin",
+      "type": [ "array", "string" ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "source": {
+      "description": "A link to of the source code repo of the theme",
+      "type": "string"
+    }
+  },
+  "required": [ "name", "description", "author" ]
 }
 ```
 
-The following is an acceptable manifest format. It should be placed as the very first thing in a CSS file:
-```css
-/**
- * @name My awesome theme
- * @authorId 435026627907420161
- * @author generic name
- * @version 1.0
- * @description A cool theme to demonstrate manifests
- * @source https://example.com/generic_name/my_awesome_theme_repo
- * @website https://example.com/cooltheme.html
-*/
+The following is an acceptable manifest format, but anything that matches the manifest is allowed.
+For example the media field may be just a single string, and some fields may be left out.
+```json
+{
+  "name": "My awesome theme",
+  "description": "A cool theme to demonstrate manifests",
+  "authorId": "123456789012345678",
+  "author": "generic name",
+  "license": "BSD-3",
+  "media": [
+    "https://cumcord.com/assets/screenshots/codcum.png",
+    "https://cumcord.com/assets/screenshots/lmao.png"
+  ],
+  "source": "https://example.com/generic_name/my_awesome_theme_repo"
+}
 
-/* write theme here - THIS COMMENT IS NOT PART OF THE MANIFEST */
 ```
 
 ---

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -32,7 +32,7 @@ declare class ThemeManifest {
  // Who wrote the theme; not required to be just one person
  author:      string;
  // An SPDX identifier for the license of your theme content - https://spdx.org/licenses/
- license:     string;
+ license?:    string;
  // The absolute URL of an image to go with your theme, screenshot or otherwise
  media?:      URL;
  // The absolute URL to the source code repo of the theme

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -27,6 +27,8 @@ declare class ThemeManifest {
  name:        string;
  // A more detail description for extra info about the theme
  description: string;
+ // The Discord ID of the theme's author - only one allowed, prioritised over author
+ authorId?:   string;
  // Who wrote the theme; not required to be just one person
  author:      string;
  // An SPDX identifier for the license of your theme content - https://spdx.org/licenses/

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -18,3 +18,20 @@ Standardise and document the manifest format (new-BD-style), what the fields mus
 
 ## General Implementation Details
  - only new BD style manifests should be carried forward into CC themes - not `//META`-style manifests
+
+I propose the following TypeScript declaration, not because it has any direct use,
+but purely to concretely define the data structure required:
+```ts
+declare class ThemeManifest {
+ // The name of the theme
+ name:        string;
+ // A more detail description for extra info about the theme
+ description: string;
+ // Who wrote the theme; not required to be just one person
+ author:      string;
+ // An SPDX identifier for the license of your theme content - https://spdx.org/licenses/
+ license:     string;
+ // The absolute URL of an image to go with your theme, screenshot or otherwise
+ media?:      URL;
+}
+```

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -38,6 +38,21 @@ declare class ThemeManifest {
 }
 ```
 
+The following is an acceptable manifest format. It should be placed as the very first thing in a CSS file:
+```css
+/**
+ * @name My awesome theme
+ * @authorId 435026627907420161
+ * @author generic name
+ * @version 1.0
+ * @description A cool theme to demonstrate manifests
+ * @source https://example.com/generic_name/my_awesome_theme_repo
+ * @website https://example.com/cooltheme.html
+*/
+
+/* write theme here - THIS COMMENT IS NOT PART OF THE MANIFEST */
+```
+
 ---
 
 Author: Yellowsink <yellowsink@protonmail.com>

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -33,6 +33,8 @@ declare class ThemeManifest {
  license:     string;
  // The absolute URL of an image to go with your theme, screenshot or otherwise
  media?:      URL;
+ // The absolute URL to the source code repo of the theme
+ source?:     URL;
 }
 ```
 

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -1,0 +1,52 @@
+# Theme manifest standards proposal
+
+## Note on themes
+Themes are not included in the core functionality of Cumcord,
+however loader plugins should use the formats specified here to allow anyone to setup a repository,
+confident that any loader plugins will work with it.
+
+Cumcord themes are required to have a manifest containing essential information and metadata about the theme.
+This includes the theme name, author, and a short description.
+
+The manifest is required to be a plain json object adhering to the following structure:
+```json
+{
+  "name": string,
+  "description": string,
+  "author": string,
+  "file": string file path,
+  "license": string,
+  "media": optional string absolute URL
+}
+```
+
+## Name
+The name field must contain the name of the plugin to identify it, and to show in user interfaces.
+
+## Description
+The description field must exist, and contain a short description of the theme, and any additional info the theme developer wishes to specify.
+It may be an empty string if the developer considers the theme simple enough, and the name self-explanatory enough.
+
+## Author
+The author field must contain the author of the plugin. Multiple authors must be specified, and while no format is required,
+the recommended format for this is to comma-separate the authors, using "and" for the last two, with no comma before the and.
+
+Discord tags may be optionally used, but there is no requirement nor special handling for this.
+
+## File
+The file field is non-negotiably required to point relatively to the index Javascript file on disk.
+This is so that the development tool (sperm) can bundle the plugin.
+
+This file must meet the following criteria:
+ - either a Javascript (\*.js) or React JSX (\*.jsx) file
+ - default export a function to be called on load - see the plugin code format specification
+
+## License
+The license field must contain an [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)
+for the licence under which your plugin's content falls.
+
+No limitations are placed upon accepatble licenses - even proprietary licenses are accepatble, however we do recommend [OSI-approved licenses](https://opensource.org/licenses).
+
+## Media
+The media field need not exist, but if it does exist, it should specify a banner image to use to represent your plugin.
+This may be a descriptive screenshot, or a more marketing-style banner, or really anything you want.

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -1,4 +1,4 @@
-# Plugin manifest standards proposal
+# Theme manifest standards proposal
 
 ## Description Of Issue
 Theme manifests should be documented and standardised. While themes are not part of Cumcord itself,


### PR DESCRIPTION
## Description Of Issue
Theme manifests should be documented and standardised. While themes are not part of Cumcord itself,
they are an essential part of most users' client mod experience,
so when theme loader plugins inevitably appear, the manifest (and repo) formats should be standardised and cross-compatible.

## Solution
Standardise and document the manifest format (new-BD-style), what the fields must be, and what each is for.