### PR TITLE
Amend manifest specs omission: Import URLs

### DIFF
--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -21,6 +21,8 @@ Standardise and document that the manifest must be a json, what the fields must 
    I think it's sensible to standardise.
  - Require the `license` field to be a valid [SPDX identifer](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange#License_syntax)
 
+**!! NOTE !! The media field is NOT for branding images.**
+
 I propose the following schema:
 ```json
 {
@@ -51,7 +53,7 @@ I propose the following schema:
       "type": "string"
     },
     "media": {
-      "description": "The absolute URL of an image to display with your plugin",
+      "description": "The absolute URL of some example images to demonstrate your plugin. No branding.",
       "type": [ "array", "string" ],
       "items": {
         "type": "string"

--- a/proposals/plugin_manifest.md
+++ b/proposals/plugin_manifest.md
@@ -91,6 +91,24 @@ The following are examples of acceptable manifests:
 }
 ```
 
+## Import URL & Hosted File Structure
+
+The import URL should be the parent route of the plugin manifest and content.
+
+The plugin content must be bundled in `plugin.js`
+(standardising the content of this file, bundling format etc, is out of scope of this spec).
+
+The plugin manifest must be in `plugin.json`.
+
+In the following example, the import URL is `example.com/my-cool-plugin`.
+```
+|- example.com
+  |- example.com/my-cool-plugin
+    |- example.com/my-cool-plugin/plugin.js
+    |- example.com/my-cool-plugin/plugin.json
+
+```
+
 ---
 
 Author: Yellowsink <yellowsink@protonmail.com>

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -18,6 +18,8 @@ Standardise and document the manifest format, what the fields must be, and what 
 
 ## Manifest Format & Schema
 
+**!! NOTE !! The media field is NOT for branding images.**
+
 I propose the following schema:
 ```json
 {
@@ -44,7 +46,7 @@ I propose the following schema:
       "type": "string"
     },
     "media": {
-      "description": "The absolute URL of an image to display with your plugin",
+      "description": "The absolute URL of some images to demonstrate your theme. No branding.",
       "type": [ "array", "string" ],
       "items": {
         "type": "string"

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -16,8 +16,7 @@ Standardise and document the manifest format, what the fields must be, and what 
 ## Disadvantages
  - locks down possibly helpful info that can be included in manifests
 
-## General Implementation Details
- - use plugin manifest -like json manifests
+## Manifest Format & Schema
 
 I propose the following schema:
 ```json
@@ -71,6 +70,24 @@ For example the media field may be just a single string, and some fields may be 
 }
 
 ```
+
+## Import URL
+
+The import URL of a theme should be the URL to the theme css file.
+The manifest should be available on the same route as this file as `cumcord_manifest.json`.
+
+In the following example, the import url is `example.com/my-cool-theme/epic_theme.css`,
+and the manifest must be available on `example.com/my-cool-theme/cumcord_manifest.json`.
+```
+|- example.com
+  |- example.com/my-cool-theme
+    |- example.com/my-cool-theme/epic_theme.css
+    |- example.com/my-cool-theme/cumcord_manifest.json
+```
+
+The import URL should always be absolute.
+This may be handled differently when referenced in theme repos (see separate spec),
+but standalone import URLs must always be absolute and to the theme file.
 
 ---
 

--- a/proposals/theme_manifest.md
+++ b/proposals/theme_manifest.md
@@ -62,7 +62,7 @@ For example the media field may be just a single string, and some fields may be 
 ```json
 {
   "name": "My awesome theme",
-  "description": "A cool theme to demonstrate manifests"
+  "description": "A cool theme to demonstrate manifests",
   "author": "generic name",
   "license": "BSD-3",
   "media": [


### PR DESCRIPTION
## Themes:
Amend to add a glaring omission to theme manifests, despite it being *thoroughly discussed* in #2: How Import URLs should work. Especially since #3 references that spec containing info on this when it didn't.

This addition follows the decided upon format in #2 discussion.

## Plugins
Standardises the format currently in use by Cumcord.

[Current implementation following this format](https://git.sr.ht/~creatable/Cumcord/tree/0a923b606904ee14f2916df4b6d5c05d061e1fdd/item/src/api/plugins/plugins.js#L101)